### PR TITLE
fix video center

### DIFF
--- a/assets/sass/theme.scss
+++ b/assets/sass/theme.scss
@@ -131,4 +131,12 @@
   }
 }
 
+// Iframe 16:9
+article .entry-content iframe {
+  display: block;
+  position: relative;
+  margin: 2rem auto;
+}
+
+
 


### PR DESCRIPTION
### 💬 Describe the pull request
C'est pas possible de garder le format 16:9 sans rajouter une div. Donc pour déjà régler en partie le problème, la vidéo est centrée.

### 🔢 To Review
Go to the article[ "L’hypnose s’installe dans les salles d’opération"](https://staging.ehnv.ch/node/1333/edit?destination=/admin/content%3Fstatus%3DAll%26type%3Darticle%26title%3D%26langcode%3DAll)